### PR TITLE
Fix some issues in the memory allocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@ impl<T> AppendOnlyVec<T> {
         self.count.store(idx, Ordering::Relaxed);
         idx
     }
+    #[allow(clippy::declare_interior_mutable_const)]
     const EMPTY: UnsafeCell<*mut T> = UnsafeCell::new(std::ptr::null_mut());
     /// Allocate a new empty array
     pub const fn new() -> Self {
@@ -450,8 +451,8 @@ fn test_parallel_pushing() {
         threads.push(std::thread::spawn(move || {
             let which1 = v.push(thread_num);
             let which2 = v.push(thread_num);
-            assert_eq!(v[which1 as usize], thread_num);
-            assert_eq!(v[which2 as usize], thread_num);
+            assert_eq!(v[which1], thread_num);
+            assert_eq!(v[which2], thread_num);
         }));
     }
     for t in threads {


### PR DESCRIPTION
This PR fixes some issues:
- The type of elements in the vector may be zero-sized type, and `std::alloc::alloc` can't allocate zero-sized memory.
- `std::alloc::alloc` will return a null pointer if the global allocator fails to allocate memory. We should handle the allocation failure using [`std::alloc::handle_alloc_error`](https://doc.rust-lang.org/std/alloc/fn.handle_alloc_error.html).